### PR TITLE
mqtt3c.lua: Ensure subscribe sets the onpub callback if it is specified in the opt table parameter.

### DIFF
--- a/src/core/.lua/mqtt3c.lua
+++ b/src/core/.lua/mqtt3c.lua
@@ -211,7 +211,7 @@ function C:subscribe(topic,callback,opt)
    if not opt and "table" == callback then
       opt,callback=callback,nil
    end
-   if opt and "function" == type(opt.onpub) then self.onpubT[topic]=onpub end
+   if opt and "function" == type(opt.onpub) then self.onpubT[topic]=opt.onpub end
    return subOrUnsub(self,topic,callback,true)
 end
 


### PR DESCRIPTION
Fixes #13 

This PR fixes the following bug in mqtt3c.lua:

Ensure subscribe sets the onpub callback if it is specified in the opt table parameter.
Currently the onpub callback is always set to nil.