### PR TITLE
Optionally include/exclude OPCUA with environment variable

### DIFF
--- a/build/Xedge.cmd
+++ b/build/Xedge.cmd
@@ -21,9 +21,17 @@ xcopy ..\..\src\core . /eq || exit /b 4
 xcopy ..\..\src\xedge . /eq || exit /b 5
 xcopy ..\..\src\mako\.lua\acme .lua\acme  /eq || exit /b 6
 
-choice /C YN /M "Do you want to include OPC-UA "
-if errorlevel 2 goto NoOPCUA
-if errorlevel 1 goto YesOPCUA
+if defined USE_OPCUA (
+   if "%USE_OPCUA%" == "1" (
+      goto YesOPCUA
+   ) else (
+      goto NoOPCUA
+   )
+) else (
+   choice /C YN /M "Do you want to include OPC-UA "
+   if errorlevel 2 goto NoOPCUA
+   if errorlevel 1 goto YesOPCUA
+)
 
 :YesOPCUA
 echo Including OPC-UA.

--- a/build/Xedge.sh
+++ b/build/Xedge.sh
@@ -23,9 +23,20 @@ cp -R ../../src/core/* . || exit 1
 cp -R ../../src/xedge/* . || exit 1
 cp -R ../../src/mako/.lua/acme/* .lua/acme || exit 1
 
-read -p "Do you want to include OPC-UA (y/n)? " userResponse
-if [ "$userResponse" = "y" ]; then
+if [ -z "$USE_OPCUA" ] ; then
+    read -p "Do you want to include OPC-UA (y/n)? " userResponse
+    if [ "$userResponse" = "y" ] ; then
+        USE_OPCUA=1
+    else
+        USE_OPCUA=0
+    fi
+fi
+
+if [ "$USE_OPCUA" != "0" ] ; then
+    echo "Including OPCUA"
     cp -R ../../src/opcua .lua/ || exit 1
+else
+    echo "Excluding OPCUA"
 fi
 
 read -p "Do you want to use the large cacert.shark or do you want to create a new with minimal certs: large/small (l/s)? " userResponse

--- a/build/mako.cmd
+++ b/build/mako.cmd
@@ -21,8 +21,29 @@ mkdir MakoBuild || exit /b 2
 cd MakoBuild || exit /b 3
 xcopy ..\..\src\core . /eq || exit /b 4
 xcopy ..\..\src\mako . /eq || exit /b 5
-xcopy ..\..\src\opcua .lua\opcua\ /eq || exit /b 6
 
+if defined USE_OPCUA (
+   if "%USE_OPCUA%" == "1" (
+      goto YesOPCUA
+   ) else (
+      goto NoOPCUA
+   )
+) else (
+   choice /C YN /M "Do you want to include OPC-UA "
+   if errorlevel 2 goto NoOPCUA
+   if errorlevel 1 goto YesOPCUA
+)
+
+:YesOPCUA
+echo Including OPC-UA.
+xcopy ..\..\src\opcua .lua\opcua\ /eq || exit /b 7
+goto ContinueAfterOPCUA
+
+:NoOPCUA
+echo OPC-UA inclusion skipped.
+goto ContinueAfterOPCUA
+
+:ContinueAfterOPCUA
 if exist "..\..\..\lua-protobuf" (
    echo Including lua-protobuf and Sparkplug lib
    copy ..\..\..\lua-protobuf\protoc.lua .lua > nul || exit /b 7

--- a/build/mako.sh
+++ b/build/mako.sh
@@ -19,7 +19,12 @@ shopt -s dotglob
 
 cp -R ../../src/core/* . || exit 1
 cp -R ../../src/mako/* . || exit 1
-cp -R ../../src/opcua .lua/ || exit 1
+if [ -z "$USE_OPCUA" ] || [ "$USE_OPCUA" != "0" ]; then
+    echo "Including OPCUA"
+    cp -R ../../src/opcua .lua/ || exit 1
+else
+    echo "Excluding OPCUA"
+fi
 
 if [ -d "../../../lua-protobuf" ]; then
     echo "Including lua-protobuf and Sparkplug lib"


### PR DESCRIPTION
For local development if OPCUA in a separate source tree it is convenient to build mako/Xedge without amalgamated OPCUA version.
